### PR TITLE
Update styles.css

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -371,13 +371,13 @@ main {
     margin-right: 10px;
 }
 
-.bass { background-position: 0 0; }
+.guitar { background-position: 0 0; }
 .drums { background-position: -30px 0; }
-.guitar { background-position: -60px 0; }
+.bass { background-position: -60px 0; }
 .vocals { background-position: -90px 0; }
-.plastic-bass { background-position: -120px 0; }
+.plastic-guitar { background-position: -120px 0; }
 .plastic-drums { background-position: -150px 0; }
-.plastic-guitar { background-position: -180px 0; }
+.plastic-bass { background-position: -180px 0; }
 
 .difficulty-bars {
     display: flex;


### PR DESCRIPTION
switched guitar and bass icons and arranged their order in the css to make more sense, as in-game the icon for the guitar is different than what is currently displayed on the website.
![image](https://github.com/user-attachments/assets/782318bd-6dea-4684-8442-77b3b073eb58)
this is how the difficulty page currently looks like.
![image](https://github.com/user-attachments/assets/1ec7b3c1-1bb8-431a-96c2-8c3b1d0a8327)
this is how it should look.
(i am a complete noob on github i hope i am doing this right)